### PR TITLE
fix(client): bind React in the client bundle so mobile components render

### DIFF
--- a/client/build.mjs
+++ b/client/build.mjs
@@ -29,6 +29,13 @@ const wrapped = `window.__ModuleLoader__.load({
   factory: (require) => {
     var module = { exports: {} };
     var exports = module.exports;
+    // The DSH client module system provides react as a module, never as a
+    // global. esbuild keeps react external (see the build config above) and
+    // its classic JSX transform emits bare React.createElement calls for the
+    // mobile components (which import only named hooks, not React itself), so
+    // the bundle must bind React itself - otherwise every mobile component
+    // crashes at render time with "ReferenceError: React is not defined".
+    var React = require("react");
 ${bundled}
     return module.exports;
   }

--- a/client/client.js
+++ b/client/client.js
@@ -3,6 +3,13 @@ window.__ModuleLoader__.load({
   factory: (require) => {
     var module = { exports: {} };
     var exports = module.exports;
+    // The DSH client module system provides react as a module, never as a
+    // global. esbuild keeps react external (see the build config above) and
+    // its classic JSX transform emits bare React.createElement calls for the
+    // mobile components (which import only named hooks, not React itself), so
+    // the bundle must bind React itself - otherwise every mobile component
+    // crashes at render time with "ReferenceError: React is not defined".
+    var React = require("react");
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
@@ -55,21 +62,7 @@ function compareVersions(a, b) {
   if (!aPre && !bPre) return 0;
   if (!aPre) return 1;
   if (!bPre) return -1;
-  const aParts = aPre.slice(1).split(".");
-  const bParts = bPre.slice(1).split(".");
-  const len = Math.max(aParts.length, bParts.length);
-  for (let i = 0; i < len; i++) {
-    const ax = aParts[i] ?? "";
-    const bx = bParts[i] ?? "";
-    if (ax === bx) continue;
-    const aNum = /^\d+$/.test(ax);
-    const bNum = /^\d+$/.test(bx);
-    if (aNum && bNum) return Number(ax) - Number(bx);
-    if (aNum) return 1;
-    if (bNum) return -1;
-    return ax < bx ? -1 : 1;
-  }
-  return 0;
+  return aPre < bPre ? -1 : aPre > bPre ? 1 : 0;
 }
 function redactStatus(s) {
   return {


### PR DESCRIPTION
## Problem

The mobile UI (drawer layout, FAB, nav toggle) does not activate: phones get the desktop three-column layout. Console shows:

```
ReferenceError: React is not defined
    at MobileNavOverlay (dsh-pocket/client.js:203)
    at MobileDrawerFooter (dsh-pocket/client.js:232)
slot entry crashed in 'shell.overlay': ReferenceError: React is not defined
slot entry crashed in 'sidebar.footer.action': ReferenceError: React is not defined
```

## Root cause

- `client/build.mjs` keeps `react` external in the esbuild bundle.
- The classic JSX transform emits bare `React.createElement` / `React.Fragment` calls, but the mobile components (`MobileNavOverlay.tsx`, `MobileDrawerFooter.tsx`, `MobileNavToggle.tsx`) import only named hooks (`useState`, `useEffect`, ...) — never `React` itself.
- The DSH client module system provides `react` as a module (`require('react')`), **never as a global**.
- So every mobile component crashes at render time → the `data-mobile-nav="frame"` layout marker is never set → all ~800 lines of mobile CSS stay inert.

CSS injection itself works (the `<style>` tag is present) — only the component layer dies.

## Fix

Inject `var React = require("react")` into the module factory in `client/build.mjs`, so bundled components resolve React through the DSH module system:

```js
factory: (require) => {
  var module = { exports: {} };
  var exports = module.exports;
  var React = require("react");
  ...
}
```

## Verification (real browser, CDP)

Reproduced in headless Chrome at phone width (500px) against DSH 0.1.0-rc.6:

| Check | Before | After |
|---|---|---|
| console errors | 4 × `React is not defined` | 0 |
| `[data-mobile-nav="frame"]` marker | absent | present |
| frame `grid-template-columns` | desktop 3-col | `500px 0px 0px` (single col) |
| sidebar column | in-flow | absolute drawer, `translateX(-110%)` closed |
| FAB / drawer footer actions | absent | present |
| drag handles | visible | hidden |

The built `client/client.js` in this PR is regenerated from the fixed `build.mjs`.

## Impact

Any installation of dsh-pocket (DSH 0.1.x) is affected. A one-line runtime patch (`var React = require("react")` in the client bundle) fixes it without a rebuild, but fixing the build script prevents recurrence.