### PR TITLE
fix: LAN QR code should prefer a phone-reachable private IPv4

### DIFF
--- a/lib/service.mjs
+++ b/lib/service.mjs
@@ -19,13 +19,54 @@ export async function qrDataUrl(text, { width = 220, margin = 1 } = {}) {
   return QRCode.toDataURL(text, { errorCorrectionLevel: 'M', margin, width, type: 'image/png' });
 }
 
-function lanIPv4() {
-  for (const ifaces of Object.values(networkInterfaces())) {
-    for (const i of ifaces ?? []) {
-      if (i.family === 'IPv4' && !i.internal) return i.address;
+/** RFC1918 私网地址：手机与电脑连同一局域网时通常可直连。 */
+const PRIVATE_IPV4_RE = /^(?:10\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)/;
+
+/** 名称像真实物理网卡的接口（WLAN / Wi-Fi / Ethernet / 以太网 / en / eth）。 */
+const PHYSICAL_IFACE_RE = /^(?:wlan|wi-?fi|wireless|ethernet|eth\d|en\d|wlp\d|以太网|本地连接)/i;
+
+/** 常见的 VPN / 虚拟网卡名称：手机通常无法通过它们直连电脑。 */
+const VPN_IFACE_RE = /(?:radmin|tailscale|zerotier|tun|tap|vpn|vethernet|virtual|vmware|virtualbox|wsl|docker|teredo|hamachi|bluetooth|bridge)/i;
+
+/**
+ * 从 networkInterfaces() 返回的接口表里选出手机最可能可达的 IPv4。
+ *
+ * `os.networkInterfaces()` 的枚举顺序不可靠：Windows 上 Radmin VPN / Tailscale /
+ * vEthernet 等虚拟网卡常排在 WLAN 前面，旧实现直接取第一张非回环网卡，会生成
+ * 手机打不开的二维码。这里按以下规则打分排序：
+ *   - RFC1918 私网地址优先（10/8、172.16/12、192.168/16）；
+ *   - 名称像物理网卡再加分；
+ *   - 名称像 VPN/虚拟网卡减分；
+ *   - 同分保持原枚举顺序。
+ * 没有任何私网地址时回退到最高分地址（例如纯 VPN 环境仍可用）。
+ *
+ * @param {ReturnType<typeof networkInterfaces>} interfaces
+ * @returns {string|null}
+ */
+export function selectLanIPv4(interfaces) {
+  const candidates = [];
+  for (const [name, addrs] of Object.entries(interfaces ?? {})) {
+    for (const addr of addrs ?? []) {
+      if (addr.family !== 'IPv4' || addr.internal) continue;
+      const ip = addr.address;
+      // 排除 loopback 与 link-local；其余地址即使不是私网（如 Radmin 的 26.x）也保留兜底
+      if (!ip || ip.startsWith('127.') || ip.startsWith('169.254.')) continue;
+
+      let score = 0;
+      if (PRIVATE_IPV4_RE.test(ip)) score += 100;
+      if (PHYSICAL_IFACE_RE.test(name)) score += 20;
+      else if (VPN_IFACE_RE.test(name)) score -= 50;
+
+      candidates.push({ ip, score, order: candidates.length });
     }
   }
-  return null;
+
+  candidates.sort((a, b) => b.score - a.score || a.order - b.order);
+  return candidates[0]?.ip ?? null;
+}
+
+function lanIPv4() {
+  return selectLanIPv4(networkInterfaces());
 }
 
 /**

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createPocketService } from '../lib/service.mjs';
+import { createPocketService, selectLanIPv4 } from '../lib/service.mjs';
 import { installPocketRpc } from '../lib/web-rpc.js';
 import { POCKET_RPC_CHANNEL, POCKET_ENDPOINTS } from '../client/api.js';
 
@@ -37,6 +37,48 @@ function stubInternals() {
     get tunnelUrl() { return tunnelUrl; },
   };
 }
+
+/** 构造 networkInterfaces() 形状的最小接口表。 */
+function ifaces(entries) {
+  return Object.fromEntries(entries.map(([name, ip]) => [name, [{ address: ip, family: 'IPv4', internal: false }]]));
+}
+
+test('selectLanIPv4：排在前面的 Radmin VPN 不遮蔽 WLAN 私网地址', () => {
+  assert.equal(
+    selectLanIPv4(ifaces([
+      ['Radmin VPN', '198.51.100.10'],
+      ['WLAN', '192.168.1.50'],
+    ])),
+    '192.168.1.50',
+  );
+});
+
+test('selectLanIPv4：两张私网网卡时优先名称像物理网卡的接口', () => {
+  assert.equal(
+    selectLanIPv4(ifaces([
+      ['vEthernet (WSL)', '172.25.0.1'],
+      ['以太网', '10.0.0.8'],
+    ])),
+    '10.0.0.8',
+    '同为 RFC1918 私网时，物理网卡优先于虚拟网卡',
+  );
+});
+
+test('selectLanIPv4：没有私网地址时回退到非回环地址（纯 VPN 环境仍可用）', () => {
+  assert.equal(
+    selectLanIPv4(ifaces([
+      ['Radmin VPN', '198.51.100.10'],
+      ['Loopback Pseudo-Interface 1', '127.0.0.1'],
+      ['WLAN', '169.254.12.34'],
+    ])),
+    '198.51.100.10',
+  );
+});
+
+test('selectLanIPv4：空接口表返回 null', () => {
+  assert.equal(selectLanIPv4({}), null);
+});
+
 
 test('service：startProxy → 局域网状态（含二维码）；startTunnel → 公网状态', async () => {
   const internals = stubInternals();


### PR DESCRIPTION
## 问题 / Problem

Windows 上如果同时存在 VPN/虚拟网卡（例如 Radmin VPN）和 WLAN，`os.networkInterfaces()` 常把虚拟网卡排在前面。`lanIPv4()` 原实现直接取第一个非回环 IPv4，导致局域网二维码指向 VPN 虚拟网卡地址，而不是手机可达的 WLAN 地址。结果是手机扫码后网页一直加载失败，但代理本身监听在 `0.0.0.0:3081`、防火墙规则也正常，问题只在选错了网卡 IP。

## 修复 / Fix

新增 `selectLanIPv4()`，按分数选择手机最可能可达的接口：

- RFC1918 私网地址优先（`10/8`、`172.16/12`、`192.168/16`）
- 名称像物理网卡（WLAN / Wi-Fi / Ethernet / 以太网 / en / eth）加分
- 已知 VPN/虚拟网卡名称（Radmin、Tailscale、ZeroTier、TUN/TAP、vEthernet/WSL、VMware、Docker 等）降权
- 同分保持原枚举顺序
- 没有任何私网地址时回退到最高分地址，纯 VPN 环境仍可用

## 验证 / Tests

新增 4 个单元测试，覆盖 Radmin VPN 排在 WLAN 前、同为私网时虚拟网卡 vs 物理网卡、纯 VPN 回退、空接口表。测试样例使用 RFC 5737 文档地址，不包含任何真实网卡 IP。本地 `npm test` 33/33 全部通过。
