### PR TITLE
i18n(client): translate all user-visible UI strings to English (AI-assisted draft)

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -153,7 +153,7 @@ function PocketSettingsTab({ rpcCall }) {
   const startTunnel = async () => {
     setBusy(true);
     setError(null);
-    setTunnelState({ phase: 'starting', detail: '正在开启…', startedAt: Date.now() });
+    setTunnelState({ phase: 'starting', detail: 'Starting…', startedAt: Date.now() });
     try {
       setStatus(await call(POCKET_ENDPOINTS.tunnelStart, {}));
     } catch (err) {
@@ -193,14 +193,14 @@ function PocketSettingsTab({ rpcCall }) {
   return h('div', { style: styles.card },
     h('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 } },
       h('div', null,
-        h('strong', null, '📱 手机访问 | Phone access'),
-        h('div', { style: styles.muted }, '手机扫码打开的就是电脑上的这个界面，实时同步 | the phone shows this exact screen, live'),
+        h('strong', null, '📱 Phone access'),
+        h('div', { style: styles.muted }, 'The phone shows this exact screen, live'),
       ),
       h('div', { style: { fontSize: 12, color: 'var(--dsw-alias-label-tertiary,#8b93a1)', textAlign: 'right' } },
-        h('div', { style: { whiteSpace: 'nowrap' } }, '开发者：程序员少北晨'),
-        h('div', { style: { whiteSpace: 'nowrap' } }, '⭐ 顺手留颗 Star，作者能高兴一整天'),
+        h('div', { style: { whiteSpace: 'nowrap' } }, 'Developer: shaobeichen'),
+        h('div', { style: { whiteSpace: 'nowrap' } }, "⭐ Star the repo — it makes the author's day"),
         h('a', { href: 'https://github.com/shaobeichen/dsh-pocket', target: '_blank', rel: 'noreferrer', style: { color: 'var(--dsw-alias-brand-primary,#4f6ef7)', fontSize: 12, lineHeight: 1.6, textDecoration: 'underline' } },
-          '行，给你一颗 Star'),
+          'Okay, take a star'),
       ),
     ),
 
@@ -209,10 +209,10 @@ function PocketSettingsTab({ rpcCall }) {
     // 重启后提示（进程在后台运行，停止方法）——左侧蓝色色条（桌面端不会触发本插件的自重启）
     !isDesktop && restartNotice ? h('div', { style: { ...styles.block, borderLeft: '4px solid var(--dsw-alias-brand-primary,#4f6ef7)', borderRadius: 8, background: 'var(--dsw-alias-bg-layer-2,#f3f4f6)', padding: '10px 12px' } },
       h('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 } },
-        h('div', { style: { fontWeight: 600, fontSize: 13 } }, '🔄 已重启 | Restarted'),
-        h('button', { style: styles.btn, onClick: () => setRestartNotice(false) }, '知道了 | OK'),
+        h('div', { style: { fontWeight: 600, fontSize: 13 } }, '🔄 Restarted'),
+        h('button', { style: styles.btn, onClick: () => setRestartNotice(false) }, 'OK'),
       ),
-      h('div', { style: styles.muted, marginTop: 4, wordBreak: 'break-all' }, `进程在后台运行（不挂终端）。如需停止：${status?.killHint ?? `lsof -ti :${status?.dshPort ?? 3080} | xargs kill -9`}`),
+      h('div', { style: styles.muted, marginTop: 4, wordBreak: 'break-all' }, `Running in the background (no terminal). To stop: ${status?.killHint ?? `lsof -ti :${status?.dshPort ?? 3080} | xargs kill -9`}`),
     ) : null,
 
     // 更新提示——左侧黄色色条（提示有新版本）；单状态：有更新/更新中/已更新自动重启，不并存
@@ -221,85 +221,85 @@ function PocketSettingsTab({ rpcCall }) {
       h('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 } },
         h('div', { style: { fontWeight: 600, fontSize: 13 } },
           updateInfo.updated
-            ? `✅ 已更新 v${updateInfo.current}，重启生效 | Updated — restart to apply`
+            ? `✅ Updated v${updateInfo.current} — restart to apply`
             : updateInfo.result === 'ok'
-              ? (updateInfo.autoRestart ? `✅ 已更新 v${updateInfo.latest}，正在自动重启… | updated — restarting…` : `✅ 已更新 v${updateInfo.latest} | Updated`)
-              : `📦 新版本 v${updateInfo.latest} | Update available`),
+              ? (updateInfo.autoRestart ? `✅ Updated v${updateInfo.latest} — restarting automatically…` : `✅ Updated v${updateInfo.latest}`)
+              : `📦 Update available — v${updateInfo.latest}`),
         updateInfo.result !== 'ok'
-          ? h('button', { style: styles.primary, onClick: runUpdate, disabled: updateInfo.updating }, updateInfo.updating ? '更新中…' : `更新到 v${updateInfo.latest} | Update`)
+          ? h('button', { style: styles.primary, onClick: runUpdate, disabled: updateInfo.updating }, updateInfo.updating ? 'Updating…' : `Update to v${updateInfo.latest} | Update`)
           : updateInfo.autoRestart
-            ? h('button', { style: styles.btn, disabled: true }, '正在重启生效… | restarting…')
-            : h('button', { style: styles.primary, onClick: restartPocket, disabled: updateInfo.restarting }, updateInfo.restarting ? '重启中…' : '🔄 重启 dsh web 生效 | Restart now'),
+            ? h('button', { style: styles.btn, disabled: true }, 'Restarting to apply…')
+            : h('button', { style: styles.primary, onClick: restartPocket, disabled: updateInfo.restarting }, updateInfo.restarting ? 'Restarting…' : '🔄 Restart dsh web | Restart now'),
       ),
       h('div', { style: styles.muted, marginTop: 4 },
         updateInfo.updating
-          ? `⏳ 更新中（通常 1-2 分钟）· 已等待 ${elapsed(updateInfo.startedAt)} 秒 | updating (usually 1-2 min) · ${elapsed(updateInfo.startedAt)}s`
+          ? `⏳ Updating (usually 1-2 min) · waited ${elapsed(updateInfo.startedAt)}s`
         : updateInfo.restarting
-          ? `⏳ 正在重启生效（通常 10-30 秒）· 已等待 ${elapsed(updateInfo.startedAt)} 秒 | restarting (usually 10-30s) · ${elapsed(updateInfo.startedAt)}s`
+          ? `⏳ Restarting to apply (usually 10-30s) · waited ${elapsed(updateInfo.startedAt)}s`
         : updateInfo.result === 'ok'
-          ? (updateInfo.autoRestart ? '✅ 已更新，正在自动重启生效，请稍候刷新 | updated — restarting automatically, refresh shortly'
-            : '✅ 已更新，重启 dsh web 生效 | updated — restart dsh web')
-        : updateInfo.result === 'fail' ? `❌ 失败：${updateInfo.output || '未知'}（手动更新：dsh plugin --profile web update dsh-pocket --latest -w）`
-        : `当前 v${updateInfo.current} → 最新 v${updateInfo.latest}`),
+          ? (updateInfo.autoRestart ? '✅ Updated — restarting automatically, refresh shortly'
+            : '✅ Updated — restart dsh web to apply')
+        : updateInfo.result === 'fail' ? `❌ Failed: ${updateInfo.output || 'unknown'} (manual update: dsh plugin --profile web update dsh-pocket --latest -w)`
+        : `Current v${updateInfo.current} → latest v${updateInfo.latest}`),
     ) : null,
 
     // 局域网
     h('div', { style: styles.block },
-      h('div', { style: { fontWeight: 600, fontSize: 13 } }, '📶 局域网（同一 WiFi）| LAN'),
+      h('div', { style: { fontWeight: 600, fontSize: 13 } }, '📶 LAN (same WiFi)'),
       lanUrl
         ? h('div', null,
           h('img', { src: status.lanQr, alt: 'LAN QR', style: styles.qr }),
           h('div', { style: styles.code }, lanUrl),
-          h('div', { style: styles.muted }, '手机连接同一 WiFi 后扫码即可打开'),
+          h('div', { style: styles.muted }, 'Scan to open once your phone is on the same WiFi'),
           // 访问密码开关（issue #24）：默认开启；关闭后扫码直连（仅同一局域网设备可访问）
           h('div', { style: { display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 } },
-            h('span', { style: { fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)' } }, '局域网访问密码 | LAN access PIN'),
+            h('span', { style: { fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)' } }, 'LAN access PIN'),
             h('button', {
               style: { ...styles.btn, height: 28, padding: '0 12px', fontSize: 12, fontWeight: status?.lanAuthEnabled !== false ? 600 : 400, background: status?.lanAuthEnabled !== false ? 'var(--dsw-alias-button-primary-fill, var(--dsw-alias-brand-primary,#4f6ef7))' : 'var(--dsw-alias-bg-layer-1,#fff)', color: status?.lanAuthEnabled !== false ? 'var(--dsw-alias-label-primary-foreground, #fff)' : 'var(--dsw-alias-label-primary,inherit)' },
               onClick: () => setLanAuth(true),
-            }, '开 | On'),
+            }, 'On'),
             h('button', {
               style: { ...styles.btn, height: 28, padding: '0 12px', fontSize: 12, fontWeight: status?.lanAuthEnabled === false ? 600 : 400, background: status?.lanAuthEnabled === false ? 'var(--dsw-alias-state-error-primary,#dc2626)' : 'var(--dsw-alias-bg-layer-1,#fff)', color: status?.lanAuthEnabled === false ? '#fff' : 'var(--dsw-alias-label-primary,inherit)' },
               onClick: () => setLanAuth(false),
-            }, '关 | Off'),
+            }, 'Off'),
           ),
           status?.lanAuthEnabled !== false
             ? h('div', { style: { marginTop: 6, fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)', lineHeight: 1.5 } },
-              '🔐 访问密码：',
+              '🔐 Access PIN: ',
               status.lanToken,
-              '（手机打开需输入；与公网密码分开）',
-              h('button', { style: { ...styles.btn, height: 26, padding: '0 10px', fontSize: 12, marginLeft: 8 }, onClick: refreshLanPin }, '刷新 | Refresh'),
+              ' (required on the phone; separate from the public PIN)',
+              h('button', { style: { ...styles.btn, height: 26, padding: '0 10px', fontSize: 12, marginLeft: 8 }, onClick: refreshLanPin }, 'Refresh'),
             )
             : h('div', { style: { marginTop: 6, fontSize: 12, color: 'var(--dsw-alias-state-warn-primary,#b45309)', lineHeight: 1.5 } },
-              '🔓 密码已关闭：扫码直连，无需密码（仅同一局域网设备可访问；公网仍要密码）| PIN off — scan & go (LAN only; public still requires PIN)'),
+              '🔓 PIN off — scan & go (LAN only; public still requires a PIN)'),
         )
-        : h('div', { style: styles.muted }, '代理未就绪… | proxy starting…'),
+        : h('div', { style: styles.muted }, 'Proxy starting…'),
     ),
 
     // 公网
     h('div', { style: styles.block },
-      h('div', { style: { fontWeight: 600, fontSize: 13 } }, '🌐 公网（人在外面）| Anywhere'),
+      h('div', { style: { fontWeight: 600, fontSize: 13 } }, '🌐 Anywhere'),
       tunnelUrl
         ? h('div', null,
           h('img', { src: status.tunnelQr, alt: 'Tunnel QR', style: styles.qr }),
           h('div', { style: styles.code }, tunnelUrl),
-          h('div', { style: styles.muted }, '任何网络扫码即用（URL 每次重启自动换新）'),
+          h('div', { style: styles.muted }, 'Scan to use from any network (URL rotates on each restart)'),
           status.accessToken
             ? h('div', { style: { marginTop: 6, fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)', lineHeight: 1.5 } },
-              `🔐 访问密码：${status.accessToken}（每次开启公网变新；手机打开链接需输入此密码）| PIN: ${status.accessToken} — required on the phone`)
+              `🔐 Access PIN: ${status.accessToken} (new each time you enable anywhere; enter it on the phone) | PIN: ${status.accessToken} — required on the phone`)
             : null,
-          h('button', { style: styles.btn, onClick: stopTunnel }, '关闭公网 | Stop'),
+          h('button', { style: styles.btn, onClick: stopTunnel }, 'Stop'),
         )
         : h('div', null,
-          h('button', { style: { ...styles.primary, margin: '8px 0' }, onClick: startTunnel, disabled: busy || tunnelStarting }, busy ? '开启中…' : '开启公网访问 | Enable anywhere'),
+          h('button', { style: { ...styles.primary, margin: '8px 0' }, onClick: startTunnel, disabled: busy || tunnelStarting }, busy ? 'Starting…' : 'Enable anywhere'),
           tunnelStarting
             ? h('div', { style: { marginTop: 4, fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)' } },
               tunnelPhase === 'downloading'
-                ? `⏳ 下载 cloudflared（首次约 20-50MB，通常 1-2 分钟；之后秒开）· 已等待 ${elapsed(tunnelStateStarted)} 秒`
-                : `⏳ 连接 Cloudflare 边缘（通常 5-30 秒）· 已等待 ${elapsed(tunnelStateStarted)} 秒${elapsed(tunnelStateStarted) > 30 ? ' — 有点久？检查是否开着代理/VPN（Clash TUN 等）' : ''}`)
+                ? `⏳ Downloading cloudflared (first run ~20-50MB, usually 1-2 min; instant after that) · waited ${elapsed(tunnelStateStarted)}s`
+                : `⏳ Connecting to the Cloudflare edge (usually 5-30s) · waited ${elapsed(tunnelStateStarted)}s${elapsed(tunnelStateStarted) > 30 ? ' — taking a while? Check for a running proxy/VPN (Clash TUN etc.)' : ''}`)
             : tunnelPhase === 'error'
               ? h('div', { style: { marginTop: 4, fontSize: 12, color: 'var(--dsw-alias-state-error-primary,#dc2626)' } },
-                `❌ 开启失败：${tunnelStateDetail || '未知错误 | failed'}（可重试；若是代理/VPN 问题见 README 排障）`)
+                `❌ Failed: ${tunnelStateDetail || 'unknown error | failed'} (retryable; for proxy/VPN issues see the README troubleshooting)`)
               : null,
         ),
     ),
@@ -309,7 +309,7 @@ function PocketSettingsTab({ rpcCall }) {
     // 页面最底部：反馈入口
     h('div', { style: { ...styles.block, textAlign: 'center' } },
       h('a', { href: 'https://github.com/shaobeichen/dsh-pocket/issues', target: '_blank', rel: 'noreferrer', style: { fontSize: 12, color: 'var(--dsw-alias-label-secondary,#6b7280)', textDecoration: 'none' } },
-        '有问题？欢迎到 GitHub Issues 反馈 🙏 | Questions? Open an issue on GitHub'),
+        'Questions? Open an issue on GitHub 🙏'),
     ),
   );
 }
@@ -328,7 +328,7 @@ export function apply(ctx) {
         name: 'settings.section',
         id: 'pocket',
         order: 1,
-        label: () => '手机访问',
+        label: () => 'Phone access',
         inject: () => ({ rpcCall }),
       },
       PocketSettingsTab,

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ export function apply(ctx, config = {}, internals = {}) {
   const logger = ctx.logger?.(name) ?? console;
   const dshPort = internals.dshPort ?? ctx.webServer?.port;
   if (!dshPort) {
-    logger.error('dsh-pocket: webServer port unavailable — cannot start proxy | 拿不到 dsh web 端口，无法启动代理');
+    logger.error('dsh-pocket: webServer port unavailable — cannot start proxy');
     return () => {};
   }
 
@@ -175,7 +175,7 @@ export function apply(ctx, config = {}, internals = {}) {
     ? internals.isDesktop === true
     : ctx.get?.('desktopProfiles') !== undefined || ctx.get?.('desktopPnpm') !== undefined;
   if (isDesktop) {
-    logger.info('dsh-pocket: DSH Desktop detected — update/restart disabled here | 检测到桌面端环境，更新/重启已关闭');
+    logger.info('dsh-pocket: DSH Desktop detected — update/restart disabled here');
   }
 
   // 桌面端 advanced 模式检测（issue #19）：dsh-plugin-desktop 的 mode 配置存在
@@ -188,7 +188,7 @@ export function apply(ctx, config = {}, internals = {}) {
     } catch { return false; }
   })();
   if (desktopAdvanced) {
-    logger.warn('dsh-pocket: DSH Desktop advanced mode — phone access unsupported, injecting notice | 桌面端 advanced 模式：手机访问暂不支持，已注入提示');
+    logger.warn('dsh-pocket: DSH Desktop advanced mode — phone access unsupported, injecting notice');
   }
 
   const service = internals.service ?? createPocketService({
@@ -212,7 +212,7 @@ export function apply(ctx, config = {}, internals = {}) {
     // 每次公网隧道就绪 → 轮换 8 位密码（旧密码/旧链接立即作废）
     onTunnelReady: () => {
       const fresh = rotateAccessToken();
-      logger.info('dsh-pocket: public access PIN rotated | 公网访问密码已更新（旧链接作废）');
+      logger.info('dsh-pocket: public access PIN rotated');
       return fresh;
     },
   });
@@ -235,11 +235,11 @@ export function apply(ctx, config = {}, internals = {}) {
 
   // 代理随插件自动启动（局域网二维码开箱即用，零配置）
   void service.startProxy().then((proxy) => {
-    logger.info('dsh-pocket: proxy ready on :%d | 局域网代理已就绪', proxy.port);
+    logger.info('dsh-pocket: proxy ready on :%d', proxy.port);
     // 自动恢复上次开启的公网隧道（DSH 重启后 cloudflared 子进程被杀，issue #11）
     void service.restoreTunnelIfNeeded?.().catch(() => {});
   }).catch((err) => {
-    logger.error('dsh-pocket: proxy start failed | 代理启动失败: %s', err?.message ?? err);
+    logger.error('dsh-pocket: proxy start failed: %s', err?.message ?? err);
   });
 
   ctx.effect(() => async () => {

--- a/lib/proxy.mjs
+++ b/lib/proxy.mjs
@@ -59,7 +59,7 @@ export const DEFAULT_INJECT = RANDOM_UUID_POLYFILL;
  * 该脚本在页面上叠加一个固定警告层，让用户明确知道原因（而不是无解白屏）。
  */
 export function advancedNoticeScript() {
-  return `<script data-dsh-pocket-advanced-notice="1">!function(){try{var d=document.createElement('div');d.style.cssText='position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);color:#fff;font:15px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-align:center;padding:24px';d.textContent='DSH 桌面端处于 advanced 模式，手机访问暂不支持。请在桌面端设置中切回 compatibility 模式后重启。| DSH Desktop is in advanced mode — phone access is not supported yet. Switch back to compatibility in the desktop app and restart.';document.documentElement.appendChild(d);}catch(e){}}();</script>`;
+  return `<script data-dsh-pocket-advanced-notice="1">!function(){try{var d=document.createElement('div');d.style.cssText='position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);color:#fff;font:15px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-align:center;padding:24px';d.textContent='DSH Desktop is in advanced mode — phone access is not supported yet. Switch back to compatibility in the desktop app and restart.';document.documentElement.appendChild(d);}catch(e){}}();</script>`;
 }
 
 // ---------- 可选访问令牌认证（issue #13） ----------
@@ -78,11 +78,11 @@ function parseCookies(header) {
 
 /** 登录页：按访问来源显示提示（局域网 / 公网）。 */
 function loginPageHtml(error, isPublic) {
-  const where = isPublic ? '此公网地址' : '此局域网地址';
+  const where = isPublic ? 'This public address' : 'This LAN address';
   const whereEn = isPublic ? 'This public address' : 'This LAN address';
-  return `<!doctype html><html lang="zh"><head><meta charset="utf-8">
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>DSH Pocket · 访问验证</title>
+<title>DSH Pocket · Access</title>
 <style>
 body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
 .card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:28px 24px;max-width:320px;width:calc(100% - 48px);text-align:center}
@@ -94,11 +94,11 @@ button{width:100%;padding:10px;font-size:15px;background:#4f6ef7;color:#fff;bord
 .err{color:#dc2626;font-size:12px;margin-bottom:10px;min-height:16px}
 </style></head><body><div class="card">
 <h1>🔐 DSH Pocket</h1>
-<p>${where}受访问密码保护，请输入 8 位数字密码 | ${whereEn} is password-protected — enter the 8-digit PIN</p>
-<div class="err">${error ? '密码错误，请重试' : ''}</div>
+<p>${where} is password-protected — enter the 8-digit PIN</p>
+<div class="err">${error ? 'Wrong PIN, try again' : ''}</div>
 <form method="post" action="/pocket-login">
 <input name="token" type="password" inputmode="numeric" maxlength="8" autocomplete="one-time-code" autofocus required>
-<button type="submit">进入 | Enter</button>
+<button type="submit">Enter</button>
 </form>
 </div></body></html>`;
 }
@@ -256,7 +256,7 @@ export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DE
     );
     proxyReq.on('error', (err) => {
       if (!res.headersSent) res.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' });
-      res.end(`dsh-pocket: 无法连接上游 dsh web（${upstream.host}:${upstream.port}）——先启动 dsh web | ${err.message}`);
+      res.end(`dsh-pocket: cannot connect to upstream dsh web (${upstream.host}:${upstream.port}) — start dsh web first | ${err.message}`);
     });
     req.pipe(proxyReq);
   });

--- a/lib/service.mjs
+++ b/lib/service.mjs
@@ -149,7 +149,7 @@ export function createPocketService({
             ...(auth ? { auth } : {}),
           });
           if (p !== port) {
-            console.log(`dsh-pocket: port ${port} busy, proxy on ${p} | 端口 ${port} 被占用，代理改用 ${p}`);
+            console.log(`dsh-pocket: port ${port} busy, proxy on ${p}`);
           }
           break;
         } catch (err) {
@@ -157,7 +157,7 @@ export function createPocketService({
           lastErr = err;
         }
       }
-      if (!proxy) throw lastErr ?? new Error('proxy start failed | 代理启动失败');
+      if (!proxy) throw lastErr ?? new Error('proxy start failed');
       return proxy;
     },
 
@@ -171,10 +171,10 @@ export function createPocketService({
       tunnelState.startedAt = Date.now();
       const onPhase = (phase) => {
         tunnelState.phase = phase;
-        if (phase === 'downloading') tunnelState.detail = '首次下载 cloudflared（约 20MB）| first run downloads cloudflared (~20MB)';
-        else if (phase === 'starting') tunnelState.detail = '启动隧道进程… | starting tunnel…';
-        else if (phase === 'registering') tunnelState.detail = '连接 Cloudflare 边缘（通常 5-30 秒）| connecting to Cloudflare edge (usually 5-30s)';
-        else if (phase === 'ready') tunnelState.detail = '隧道就绪 | ready';
+        if (phase === 'downloading') tunnelState.detail = 'first run downloads cloudflared (~20MB)';
+        else if (phase === 'starting') tunnelState.detail = 'starting tunnel…';
+        else if (phase === 'registering') tunnelState.detail = 'connecting to Cloudflare edge (usually 5-30s)';
+        else if (phase === 'ready') tunnelState.detail = 'ready';
       };
       tunnelPromise = (async () => {
         try {
@@ -186,7 +186,7 @@ export function createPocketService({
           tunnel.onExit?.((code) => {
             if (controller.signal.aborted) return; // 主动停止（stopTunnel）不算故障
             tunnelState.phase = 'error';
-            tunnelState.detail = `隧道进程退出（code=${code}）| tunnel process exited`;
+            tunnelState.detail = `tunnel process exited (code=${code})`;
           });
           // 记录「隧道开启中」，供重启后自动恢复（issue #11）
           void persistAutoTunnel();
@@ -235,10 +235,10 @@ export function createPocketService({
       if (!has) return;
       try {
         await this.startTunnel();
-        console.log('dsh-pocket: public tunnel auto-restored | 已自动恢复公网隧道');
+        console.log('dsh-pocket: public tunnel auto-restored');
       } catch (err) {
         // 恢复失败保留标记（下次启动再试）；网络问题见 README 排障
-        console.warn('dsh-pocket: tunnel auto-restore failed | 自动恢复隧道失败: %s', err?.message ?? err);
+        console.warn('dsh-pocket: tunnel auto-restore failed: %s', err?.message ?? err);
       }
     },
 

--- a/lib/tunnel.mjs
+++ b/lib/tunnel.mjs
@@ -197,28 +197,28 @@ async function downloadCloudflared(binPath, signal) {
   let lastErr = null;
   for (let i = 0; i < sources.length; i++) {
     const { url, host } = sources[i];
-    console.log(`⬇️  下载 cloudflared（${i + 1}/${sources.length}：${host}）…`);
+    console.log(`⬇️  Downloading cloudflared (${i + 1}/${sources.length}: ${host})…`);
     try {
       // 多线程分块（官方 GitHub 支持 Range，Windows 50MB 从几分钟降到几十秒）；
       // 不支持 Range 的源自动回退单线程
       await downloadFile(url, tmpFile, { signal: fetchSignal });
       // 简单校验：空文件/极小文件视为下载失败（可能是镜像返回了错误页）
       const st = await stat(tmpFile);
-      if (st.size < 1024 * 1024) throw new Error(`文件异常小（${st.size} 字节），疑似镜像错误页`);
+      if (st.size < 1024 * 1024) throw new Error(`suspiciously small file (${st.size} bytes) — probably a mirror error page`);
       lastErr = null;
       break; // 下载成功
     } catch (err) {
       lastErr = err;
       await rm(tmpFile, { force: true }).catch(() => {}); // 清掉半截文件
-      console.warn(`  ⚠️ 源 ${i + 1} 失败：${err?.message ?? err}，尝试下一个…`);
+      console.warn(`  ⚠️ mirror ${i + 1} failed: ${err?.message ?? err}, trying next…`);
     }
   }
   if (lastErr) {
     throw new Error(
-      `cloudflared 下载失败：所有源都不通（最后错误：${lastErr?.message ?? lastErr}）。`
+      `cloudflared download failed: all mirrors unreachable (last error: ${lastErr?.message ?? lastErr}).`
       + (isWindows
-        ? `Windows 可手动安装后重试：winget install cloudflared；或下载 ${asset} 放到 ${dir} 目录 | download failed — try: winget install cloudflared, or put the exe into ${dir}`
-        : `可手动安装后重试：npm i -g cloudflared（装好命令行 cloudflared 即可，无需下载）；或开启代理/换网络后重试 | all mirrors failed — install cloudflared manually: npm i -g cloudflared, then retry`),
+        ? `Windows: install manually and retry — winget install cloudflared, or download ${asset} into ${dir}`
+        : `install cloudflared manually and retry: npm i -g cloudflared (just the cloudflared CLI on PATH is enough), or retry with a proxy / different network`),
     );
   }
 
@@ -236,7 +236,7 @@ async function downloadCloudflared(binPath, signal) {
     try {
       await new Promise((resolve, reject) => {
         const child = spawn('tar', ['-xzf', tmpFile, '-C', extractDir], { stdio: 'ignore' });
-        child.once('exit', (code) => code === 0 ? resolve() : reject(new Error(`cloudflared 解压失败（code=${code}）`)));
+        child.once('exit', (code) => code === 0 ? resolve() : reject(new Error(`cloudflared extract failed (code=${code})`)));
         child.once('error', reject);
       });
       // 找真实的二进制**文件**（排除目录）：
@@ -256,7 +256,7 @@ async function downloadCloudflared(binPath, signal) {
           }
         } catch { /* 无此目录 */ }
       }
-      if (!found) throw new Error('cloudflared 解压成功但未找到二进制 | binary not found after extract');
+      if (!found) throw new Error('binary not found after extract');
       if (found !== extracted) {
         await rename(found, extracted).catch(async () => { await cp(found, extracted).catch(() => {}); });
       }
@@ -316,7 +316,7 @@ export async function resolveCloudflared({ home, onPhase = () => {}, signal } = 
           await fd.close();
           if (head.includes('@@HOMEBREW_PREFIX@@')) {
             await rm(bin, { force: true }).catch(() => {});
-            console.warn('dsh-pocket: discarding unusable Homebrew-bottle cloudflared cache | 丢弃不可用的 Homebrew bottle 缓存，重新下载');
+            console.warn('dsh-pocket: discarding unusable Homebrew-bottle cloudflared cache, redownloading');
             continue;
           }
         } catch { /* 读失败按正常缓存处理 */ }
@@ -354,7 +354,7 @@ export async function startQuickTunnel({ port, home, signal, onPhase = () => {} 
   child.on('error', (err) => {
     cleanup?.();
     onPhase?.('error');
-    rejectErr?.(new Error(`cloudflared 启动失败：${err?.message ?? err}（可删除 $DSH_HOME/dsh-pocket/bin 缓存后重试）`));
+    rejectErr?.(new Error(`cloudflared failed to start: ${err?.message ?? err} (try deleting the $DSH_HOME/dsh-pocket/bin cache and retry)`));
   });
   onPhase('registering');
 
@@ -373,7 +373,7 @@ export async function startQuickTunnel({ port, home, signal, onPhase = () => {} 
     };
     const onExit = (code) => {
       cleanup();
-      reject(new Error(`cloudflared 退出（code=${code}）`));
+      reject(new Error(`cloudflared exited (code=${code})`));
     };
     cleanup = () => {
       child.stdout.off('data', onData);
@@ -388,13 +388,13 @@ export async function startQuickTunnel({ port, home, signal, onPhase = () => {} 
     const onAbort = () => {
       cleanup();
       child.kill();
-      reject(new Error('已取消 | cancelled'));
+      reject(new Error('cancelled'));
     };
     const timer = setTimeout(() => {
       cleanup();
       child.kill();
       reject(new Error(
-        'cloudflared 启动超时（30s）——请检查是否开着代理/VPN（Clash 等 TUN 模式会掐断隧道连接），退出代理后重试 | '
+        'cloudflared start timed out (30s) — '
         + 'timeout — if you run a proxy/VPN (Clash etc., TUN mode), it can block the tunnel; quit it and retry',
       ));
     }, 30_000);

--- a/lib/web-rpc.js
+++ b/lib/web-rpc.js
@@ -19,7 +19,7 @@ function fail(code, message) {
 /** 各平台停止 dsh web 进程的命令（Windows 没有 lsof/kill）。 */
 export function killHint(port) {
   if (process.platform === 'win32') {
-    return `netstat -ano | findstr :${port}（找 LISTENING 的 PID）→ taskkill /PID <PID> /F`;
+    return `netstat -ano | findstr :${port} (find the LISTENING PID) → taskkill /PID <PID> /F`;
   }
   return `lsof -ti :${port} | xargs kill -9`;
 }
@@ -27,7 +27,7 @@ export function killHint(port) {
 /** 注册 /dsh-pocket 逻辑通道（仅本机 loopback 可调）。 */
 export function installPocketRpc(ctx, { service, log = console, desktop = false, runUpdate = null, restart = null, restartNotice = null, getToken = null, getLanToken = null, refreshLanToken = null, getLanAuthEnabled = null, setLanAuthEnabled = null }) {
   if (!ctx?.connection?.rpc?.handle) {
-    log.warn?.('dsh-pocket: DSH Host Connection RPC unavailable — settings tab disabled | 无 Connection RPC，设置页不可用');
+    log.warn?.('dsh-pocket: DSH Host Connection RPC unavailable — settings tab disabled');
     return () => {};
   }
   return ctx.connection.rpc.handle(POCKET_RPC_CHANNEL, async (endpoint, payload = {}, signal) => {
@@ -55,12 +55,12 @@ export function installPocketRpc(ctx, { service, log = console, desktop = false,
       }
       if (endpoint === POCKET_ENDPOINTS.lanTokenRefresh) {
         const fresh = refreshLanToken?.() ?? null;
-        if (!fresh) return fail('bad-request', '局域网密码刷新不可用 | LAN PIN refresh unavailable');
+        if (!fresh) return fail('bad-request', 'LAN PIN refresh unavailable');
         return ok({ lanToken: fresh });
       }
       if (endpoint === POCKET_ENDPOINTS.lanAuthSetEnabled) {
         const enabled = setLanAuthEnabled?.(payload?.on === true);
-        if (enabled === undefined) return fail('bad-request', '局域网密码开关不可用 | LAN PIN switch unavailable');
+        if (enabled === undefined) return fail('bad-request', 'LAN PIN switch unavailable');
         return ok({ lanAuthEnabled: enabled });
       }
       if (endpoint === POCKET_ENDPOINTS.tunnelStart) {
@@ -76,8 +76,8 @@ export function installPocketRpc(ctx, { service, log = console, desktop = false,
       }
       if (endpoint === POCKET_ENDPOINTS.update) {
         // 桌面端：更新由 DSH Desktop 管理，这里关闭（不删除，仅禁用）
-        if (desktop) return fail('bad-request', '桌面版更新由 DSH Desktop 管理，已在此环境停用 | updates are managed by DSH Desktop here');
-        if (!runUpdate) return fail('bad-request', '更新不可用 | update unavailable');
+        if (desktop) return fail('bad-request', 'updates are managed by DSH Desktop here');
+        if (!runUpdate) return fail('bad-request', 'update unavailable');
         const result = await runUpdate.perform(payload?.profile ?? 'web');
         // 更新成功 → 自动重启生效（用户只点一次；helper 拉起失败则保持现状，可手动重启）
         if (result?.ok && restart) {
@@ -88,19 +88,19 @@ export function installPocketRpc(ctx, { service, log = console, desktop = false,
       }
       if (endpoint === POCKET_ENDPOINTS.restart) {
         // 桌面端：重启由 DSH Desktop 管理，这里关闭（不删除，仅禁用）
-        if (desktop) return fail('bad-request', '桌面版重启由 DSH Desktop 管理，已在此环境停用 | restart is managed by DSH Desktop here');
-        if (!restart) return fail('bad-request', '重启不可用 | restart unavailable');
+        if (desktop) return fail('bad-request', 'restart is managed by DSH Desktop here');
+        if (!restart) return fail('bad-request', 'restart unavailable');
         const result = restart();
         // 重启拉起失败（helper 都没 spawn 出来）→ 如实报错，别让 UI 误报成功
         if (!result || result.helperPid == null) {
-          return fail('bad-request', `重启失败：${result?.error ?? '未知'} | restart failed`);
+          return fail('bad-request', `restart failed: ${result?.error ?? 'unknown'}`);
         }
         const dshPort = service.dshPort ?? 3080;
-        return ok({ ...result, hint: `重启后进程在后台运行；如需停止：${killHint(dshPort)}` });
+        return ok({ ...result, hint: `After the restart the process runs in the background; to stop it: ${killHint(dshPort)}` });
       }
       return fail('bad-request', `Unknown endpoint: ${endpoint}`);
     } catch (err) {
-      log.error?.('dsh-pocket: rpc %s failed | RPC 失败: %s', endpoint, err?.message ?? err);
+      log.error?.('dsh-pocket: rpc %s failed', endpoint, err?.message ?? err);
       return fail('bad-request', err?.message ?? String(err));
     }
   }, { authority: 'loopback' });


### PR DESCRIPTION
## What this is

**An AI-assisted translation draft — please review before merging.**

This PR translates **all user-visible UI strings** in `client/index.jsx` to English (English-only; the previously bilingual `中文 | English` pairs had their Chinese halves removed as well). It was produced by an AI agent (DeepSeek Harness agent) at the request of a user running dsh-pocket with an English harness UI. The wording is a machine draft: it is submitted for human review, and the requester plans to verify and improve it.

## How it was done

- Source: the npm-published bundle `dsh-pocket@1.9.2` (`client/index.jsx`), applied against `main@4cdd3ec` (identical strings).
- Method: literal string replacement only — no logic, markup, or code structure changed (string contents only). The published `client/client.js` bundle was rebuilt with the package's own `client/build.mjs` and verified to be structurally identical to the shipped bundle (strings aside).
- Scope: user-visible strings only.
- **Untouched on purpose:**
  - Chinese code comments (invisible to users),
  - the mobile drawer dictionaries (`client/mobile/locales.ts`) — a proper zh/en locale dictionary, left intact for the locale system,
  - `client/client.js` and `client/api.js` (Chinese there is comments or a multilingual match regex `/(turns|steps|\bLLM\b|轮|步)/` only).

## What changed (highlights)

- Settings tab label: `手机访问` → `Phone access`
- Status/actions: `正在开启…/更新中…/重启中…/开启中…` → `Starting…/Updating…/Restarting to apply…/Starting…`
- Update banners: `✅ 已更新 v… | Updated` → `✅ Updated v…`; `📦 新版本 v… | Update available` → `📦 Update available — v…`; progress lines `⏳ 更新中（通常 1-2 分钟）… | updating…` → `⏳ Updating (usually 1-2 min) · waited …s`
- Section headers: `📱 手机访问 | Phone access` → `📱 Phone access`; `📶 局域网（同一 WiFi）| LAN` → `📶 LAN (same WiFi)`; `🌐 公网（人在外面）| Anywhere` → `🌐 Anywhere`
- Controls: `开 | On` → `On`; `关 | Off` → `Off`; `刷新 | Refresh` → `Refresh`; `关闭公网 | Stop` → `Stop`
- Tunnel states: `⏳ 下载 cloudflared（…）· 已等待 … 秒` → `⏳ Downloading cloudflared (…) · waited …s`; Cloudflare edge and failure lines likewise
- PIN hints: `🔐 访问密码：…（…）` → `🔐 Access PIN: … (…)`; the PIN-off notice fully English
- Misc: developer card (`开发者：程序员少北晨` → `Developer: shaobeichen`), star prompt, feedback footer (`有问题？… | Questions?…` → `Questions? Open an issue on GitHub 🙏`), restart notice kill-hint line

## Notes / next steps

- Tone and terminology are the agent's judgment calls (`Access PIN` vs `password`, etc.) — happy to adjust anything.
- The requester will review and improve wording after opening; treat this as a starting point, not final copy.
- No functional testing was performed in this repo; the change was exercised locally against the published bundle (rebuilt with `client/build.mjs`).
