### PR TITLE
fix(proxy): inject WebSocket ping heartbeat to defeat silent link drops

### DIFF
--- a/lib/proxy.mjs
+++ b/lib/proxy.mjs
@@ -132,6 +132,59 @@ function loopbackAuthority(headers, upstream) {
   return headers;
 }
 
+// ---------- WebSocket 心跳注入 ----------
+// DSH 客户端与宿主的 WebSocket downlink 都不发 ping/pong（客户端只读流、
+// 宿主只推帧），空闲连接会被路由器 NAT 空闲超时或手机系统省电机制**静默**
+// 丢弃：没有 FIN/RST，浏览器收不到 close 事件，dsh-client-connection 也就
+// 永远不会重连——手机页面看起来还开着，实则实时通道已死（消息不同步、
+// 点击会话卡在加载）。
+//
+// 代理在每个透传的 WS 连接上定期向浏览器侧发送协议层 Ping（0x89 0x00，
+// server→client 不掩码）：
+//   - 浏览器网络栈按 RFC 6455 自动回 Pong（不经过任何 JS），一来一回让
+//     双向都有流量，NAT/防火墙空闲超时不再触发；
+//   - 连续 missLimit 个周期没有任何入站字节（浏览器已死或链路被静默丢弃）
+//     → 主动 destroy 连接：浏览器拿到 close 后 dsh-client-connection 会
+//     按指数退避自动重连，实时通道随即恢复。
+// 只 Ping 浏览器侧：上游是本机 loopback，不会过期；浏览器回的 Pong 原样
+// 透传给上游 ws 服务（未请求的 Pong 对 ws 库无害，只触发无害的 pong 事件）。
+const WS_PING_FRAME = Buffer.from([0x89, 0x00]); // FIN + opcode 9、长度 0、不掩码
+
+/**
+ * 在透传的浏览器侧 socket 上挂载心跳：定期 Ping 保活 + 静默断链检测。
+ * 任一路由方向只要有字节流动（Pong 响应）就把静默计数归零；连续 missLimit
+ * 个周期零入站流量则判定链路已死，销毁 socket 触发浏览器端重连。
+ * @param {import('node:net').Socket} socket 浏览器侧的透传 socket
+ * @param {{intervalMs?:number, missLimit?:number}} [opts] 心跳周期与容忍的静默周期数
+ */
+function attachWebSocketHeartbeat(socket, { intervalMs = 30_000, missLimit = 2 } = {}) {
+  let misses = 0;
+  let stopped = false;
+  const onInbound = () => { misses = 0; };
+  const timer = setInterval(() => {
+    if (stopped) return;
+    misses += 1;
+    if (misses >= missLimit) {
+      // 连续多个周期没有任何入站流量（连 Pong 都没有）→ 静默断链，断开让客户端重连
+      socket.destroy();
+      return;
+    }
+    socket.write(WS_PING_FRAME);
+  }, intervalMs);
+  timer.unref?.();
+  socket.on('data', onInbound);
+  const cleanup = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+    socket.off('data', onInbound);
+    socket.off('close', cleanup);
+    socket.off('error', cleanup);
+  };
+  socket.on('close', cleanup);
+  socket.on('error', cleanup);
+}
+
 /**
  * 启动 dsh-pocket 代理。
  * @param {object} opts
@@ -140,9 +193,10 @@ function loopbackAuthority(headers, upstream) {
  * @param {{host:string,port:number}} [opts.upstream] 上游 dsh web（默认 127.0.0.1:3080）
  * @param {string} [opts.injectHtml] 注入 HTML 的内容（默认 polyfill + 移动端适配；传 '' 关闭）
  * @param {object} [opts.auth]       可选访问令牌认证（issue #13）：{ getToken, isProtected }
+ * @param {object|false} [opts.heartbeat] WebSocket 心跳注入：{ intervalMs, missLimit }；false 关闭（默认开：30s/容忍 2 个静默周期）
  * @returns {Promise<{server:import('node:http').Server, close:()=>Promise<void>}>}
  */
-export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DEFAULT_UPSTREAM, log = null, injectHtml = DEFAULT_INJECT, auth = null } = {}) {
+export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DEFAULT_UPSTREAM, log = null, injectHtml = DEFAULT_INJECT, auth = null, heartbeat = {} } = {}) {
   const server = createServer((req, res) => {
     // 访问令牌认证（issue #13 + #18）：局域网与公网都要求密码
     if (auth) {
@@ -288,6 +342,8 @@ export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DE
       if (proxyHead?.length) socket.write(proxyHead);
       proxySocket.pipe(socket);
       socket.pipe(proxySocket);
+      // 心跳注入：保活 + 静默断链检测（见 attachWebSocketHeartbeat）
+      if (heartbeat !== false) attachWebSocketHeartbeat(socket, heartbeat ?? {});
       // 任一端断开都要清理另一端（避免上游残留僵尸连接占用 dsh 连接槽）
       const teardown = () => { try { proxySocket.destroy(); } catch {} try { socket.destroy(); } catch {} };
       proxySocket.on('close', teardown);


### PR DESCRIPTION
## 问题

手机扫码访问时（issue #29 同款症状）：页面能打开、会话列表能加载，但**实时同步失效**——AI 回复不滚动、点击会话卡在 New Session。

## 根因

DSH 客户端与宿主的 WebSocket downlink 都**没有 ping/pong 保活**：

- 手机浏览器与电脑之间一旦空闲几分钟，路由器 NAT 空闲超时或手机省电机制会**静默**丢弃该 TCP 流（无 FIN/RST）；
- 浏览器收不到 close 事件，`dsh-client-connection` 认为连接正常，**永远不会重连**；
- 实测观察（Windows `Get-NetTCPConnection`）：手机到代理的 5 条连接建立后 12 分钟零流量、零重连——典型的静默断链；
- 实时事件（`/api/events.mux`、`/api/events.host`）随之断流，会话历史请求又恰好复用了死掉的 keep-alive 连接 → 卡在加载。

## 修复

在代理的 WebSocket 透传建立后，向**浏览器侧**定期发送协议层 Ping 帧（`0x89 0x00`，server→client 不掩码）：

1. **保活**：浏览器网络栈按 RFC 6455 自动回 Pong（无需任何 JS），双向产生流量，NAT 空闲超时不再触发；
2. **静默断链检测**：连续 `missLimit`（默认 2）个周期没有任何入站字节 → 主动 destroy 连接 → 浏览器收到 close → `dsh-client-connection` 按指数退避自动重连，实时通道恢复。

细节：

- 只 Ping 浏览器侧：上游是本机 loopback，不会过期；浏览器回的 Pong 原样透传给上游 ws 服务（未请求的 Pong 对 ws 库无害，仅触发无害的 pong 事件）；
- 默认 `intervalMs: 30_000`、`missLimit: 2`（约 60 秒判定死亡）；通过 `createPocketProxy({ heartbeat })` 可调，传 `false` 关闭；
- 定时器随 close/error 清理，`unref()` 不阻止进程退出。

## 验证

连真实 DSH 宿主（127.0.0.1:3080）实测：

- 健康客户端（自动回 Pong）：持续收到 Ping，mux 帧正常下发（4 帧），连接保持 OPEN；
- 死链路客户端（不回 Pong，模拟静默断链）：`missLimit` 个周期后（测试参数 1s×3 = 3 秒）被代理主动断开（close 1006），浏览器端随即触发自动重连。

Closes #29
