### PR TITLE
fix(mobile): raise drawer above shell overlay raised by third-party plugins

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -448,13 +448,18 @@ var MOBILE_CSS = `
      the viewport. A mere -100% leaves a sliver on screen; -105% (as used
      before) left 14px of the drawer plus a long 32px-blur shadow gradient
      visible along the left edge of the main UI. No box-shadow at all: the
-     dimmed backdrop already separates drawer from content. */
+     dimmed backdrop already separates drawer from content.
+     Z-index note: third-party plugins can force the shell overlay layer up
+     via !important (dsh-update-checker sets it to 500), which would paint
+     the backdrop ABOVE the drawer and swallow every tap (the drawer opens
+     but every tap just closes it). 600 keeps the drawer above any such
+     raise while staying under fixed viewport banners (z 9999). */
   [data-mobile-nav="frame"] > :first-child {
     position: absolute !important;
     inset: 0 auto 0 0 !important;
     width: max-content !important;
     max-width: 92vw !important;
-    z-index: 40 !important;
+    z-index: 600 !important;
     transform: translateX(-110%);
     transition: transform .28s var(--ds-ease-in-out, ease-in-out);
     background: var(--dsw-alias-bg-base, #ffffff);

--- a/client/mobile/mobile.css.ts
+++ b/client/mobile/mobile.css.ts
@@ -194,13 +194,21 @@ export const MOBILE_CSS = `
      the viewport. A mere -100% leaves a sliver on screen; -105% (as used
      before) left 14px of the drawer plus a long 32px-blur shadow gradient
      visible along the left edge of the main UI. No box-shadow at all: the
-     dimmed backdrop already separates drawer from content. */
+     dimmed backdrop already separates drawer from content.
+     Z-index note: the backdrop renders inside the shell's overlay layer
+     ([data-shell-overlay]), which forms its own stacking context. Third-party
+     plugins can force that layer up with !important (dsh-update-checker sets
+     it to 500), and when the layer outranks the drawer, the backdrop paints
+     ABOVE the drawer and swallows every tap — the drawer opens but no row
+     can be pressed (every tap just closes it). The drawer must therefore
+     outrank any such raise: 600 clears the known 500 while staying under the
+     fixed-position banners/toasts (z 9999) that float at the viewport level. */
   [data-mobile-nav="frame"] > :first-child {
     position: absolute !important;
     inset: 0 auto 0 0 !important;
     width: max-content !important;
     max-width: 92vw !important;
-    z-index: 40 !important;
+    z-index: 600 !important;
     transform: translateX(-110%);
     transition: transform .28s var(--ds-ease-in-out, ease-in-out);
     background: var(--dsw-alias-bg-base, #ffffff);


### PR DESCRIPTION
## 问题

手机上：能呼出左侧抽屉、能看到会话列表，但**点击抽屉里任何位置都只是关闭抽屉**，行点击不生效（会话打不开、按钮无响应）。

## 根因

抽屉的层叠关系被第三方插件破坏：

- dsh-pocket 的移动端抽屉是 `z-index: 40`，背板（backdrop）渲染在 shell 的 overlay 层（`[data-shell-overlay]`）里；
- `dsh-update-checker` 等第三方插件会注入 `[data-shell-overlay]{z-index:500!important}`，把整个 overlay 层抬成 z=500 的层叠上下文；
- 40 < 500 → 背板画在抽屉**上面**并吞掉所有点击（背板的 onClick 是关闭抽屉），抽屉"看得见、摸不着"。

无头 Chromium（390×844 + 触摸模拟）复现：`document.elementFromPoint(会话行中心)` 命中的是 backdrop。

## 修复

把抽屉 `z-index` 从 40 提升到 **600**：

- 高于已知的 overlay 层抬升（500），低于视口级固定横幅（9999）；
- 背板的"点击外部关闭"行为保持不变；抽屉内容（包括 portal 进 sidebar 的设置面板）依然在背板之上。

源码（`client/mobile/mobile.css.ts`）与线上 bundle（`client/client.js`）同步更新，并补充注释说明原因。

## 验证

修复后同环境实测：`elementFromPoint` 命中 `sessionRow` 行内容；点击会话 → 会话在主区域打开（phase 变为 active、标题出现）、抽屉按设计收起。

## 附带建议

`dsh-update-checker` 的横幅自身已是 `position:fixed; z-index:9999`，其实不需要用 `!important` 抬整个 overlay 层；那边也可以改为不再全局抬层。
