### PR TITLE
fix(proxy): attach error handler to upstream WS socket to prevent dsh web process crash

### DIFF
--- a/lib/proxy.mjs
+++ b/lib/proxy.mjs
@@ -445,6 +445,9 @@ export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DE
       if (heartbeat !== false) attachWebSocketHeartbeat(socket, heartbeat ?? {});
       // 任一端断开都要清理另一端（避免上游残留僵尸连接占用 dsh 连接槽）
       const teardown = () => { try { proxySocket.destroy(); } catch {} try { socket.destroy(); } catch {} };
+      // 上游侧透传 socket 的读错误（如 dsh web 重启/断开时的 ECONNRESET）必须
+      // 吞掉并清理对端，否则未处理的 'error' 事件会让整个 dsh web 进程崩溃退出。
+      proxySocket.on('error', () => { try { socket.destroy(); } catch {} });
       proxySocket.on('close', teardown);
       socket.on('close', teardown);
     });


### PR DESCRIPTION
## 问题

`dsh web` 进程会偶发崩溃退出，终端留下：

```
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance
    at Socket.onerror (node:internal/streams/readable:1035:14)
```

## 根因

`lib/proxy.mjs` 的 WebSocket upgrade 透传分支里，浏览器侧 socket 挂了 error 监听（upgrade handler 末尾的 `socket.on('error', ...)`），但 `proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => ...)` 中从上游拿回的 **`proxySocket` 只监听了 `'close'`，从未监听 `'error'`**。

一旦上游（dsh web:3080）对这条连接发送 RST——例如 dsh web 自身的连接清理/重启、服务端主动销毁 socket——`proxySocket` 读到 `ECONNRESET`，该 `'error'` 事件没有任何监听器，作为 uncaught exception 直接终止整个 `dsh web` 宿主进程（代理与宿主同进程）。

其余路径均有兜底：入站 TCP 连接在 `server.on('connection')` 里挂了空 error 处理，普通 HTTP 转发的 `proxyReq` / `proxyRes` 也都有 error 监听；唯独 upgrade 后的上游侧 socket 是缺口。

## 复现

确定性复现（3/3 稳定红）：

1. 假上游接受一次 WS upgrade 后保持连接；
2. `createPocketProxy()` 指向它；
3. 客户端经代理完成 WS 握手；
4. 假上游对该连接调用 `socket.resetAndDestroy()` 发送 RST。

未修复时代理进程每次都以 `Error: read ECONNRESET / Emitted 'error' event on Socket instance` 崩溃退出；打上本补丁后同一回路 3/3 稳定存活并正常清理两端。

## 修复

一行兜底 + 两行注释：给上游侧透传 socket 补上 error 监听，出错时清理对端（与既有 teardown 语义一致）：

```js
proxySocket.on('error', () => { try { socket.destroy(); } catch {} });
```

已在 Windows 11 + Node v24.18.0 的真实环境验证：本地安装 dsh-pocket 后应用此改动，此前数小时一崩的 `dsh web` 不再因该路径退出。
