### PR TITLE
fix(update): Windows 自动更新 spawn dsh ENOENT —— 走 shell 启动

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,6 +168,8 @@ function performUpdate(profile, { timeoutMs = 180_000 } = {}) {
   return new Promise((resolve) => {
     const child = spawn('dsh', ['plugin', '--profile', profile, 'update', 'dsh-pocket', '--latest', '-w'], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Windows 上裸 spawn('dsh') 解析到无扩展名 POSIX shim → ENOENT；Node 22+ 直接 spawn .cmd 会 EINVAL（CVE-2024-27980），必须走 shell
+      shell: process.platform === 'win32',
     });
     let out = '';
     const onData = (c) => { out += String(c); if (out.length > 4000) out = out.slice(-4000); };


### PR DESCRIPTION
## 问题

Windows 上点「更新到新版本」报错：`❌ 失败：spawn dsh ENOENT`，手动执行同一条 `dsh plugin --profile web update dsh-pocket --latest -w` 则正常。

## 根因

`lib/index.js` 的 `performUpdate` 裸 `spawn('dsh', ...)` 不带 `shell`：

1. npm 全局安装的 CLI 在 Windows 上生成三个 shim（`dsh` / `dsh.cmd` / `dsh.ps1`）。`spawn` 走 libuv 解析时先命中**无扩展名的 POSIX 脚本** `dsh`，Windows 的 CreateProcess 无法直接执行 → ENOENT；
2. 即使改用 `dsh.cmd` 也不行：Node ≥ 22.0.0 因 [CVE-2024-27980](https://nodejs.org/pt/blog/vulnerability/april-2024-security-releases-2) 安全修复，对 `.bat`/`.cmd` 的直接 spawn 一律返回 EINVAL，必须走 `shell: true`。

## 修复

一行，与 dsh 核心 `@deepseek-ai/dsh` 的 `plugin-9h8shc4d.js` 中 pnpm 调用（`shell: process.platform === "win32"`）的处理方式保持一致：

```diff
 const child = spawn('dsh', ['plugin', '--profile', profile, 'update', 'dsh-pocket', '--latest', '-w'], {
   stdio: ['ignore', 'pipe', 'pipe'],
+  shell: process.platform === 'win32',
 });
```

## 验证

- Windows 11 / Node 22.17.1 实测：修复前 `spawn('dsh', ...)` → ENOENT，`spawn('dsh.cmd', ...)` → EINVAL；修复后（`shell: true`）正常退出 0，更新流程跑通
- 测试：`npm test` 与基线一致（仅 WSL 环境检测一项环境相关失败，改动前后无差异；另有隧道相关 flaky 测试偶发）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
