### PR TITLE
fix(proxy): destroy WS peers on FIN to avoid half-open slot leak

### DIFF
--- a/lib/proxy.mjs
+++ b/lib/proxy.mjs
@@ -453,6 +453,12 @@ export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DE
       proxySocket.on('error', () => { try { socket.destroy(); } catch {} });
       proxySocket.on('close', teardown);
       socket.on('close', teardown);
+      // 半关闭（收到对端 FIN 的 'end'）对双向转发同样意味着这一端要走了：http server
+      // 默认 allowHalfOpen=true，收到 FIN 只触发 'end' 不自动关——若不在 'end' 时销毁，
+      // 浏览器/App 直接关页（不发 WS close 帧就 FIN）留下的连接会永久挂在 half-open
+      // 状态，上游连接槽被占（且 server.close() 永远等不完）。双向流里半关闭无意义。
+      socket.on('end', teardown);
+      proxySocket.on('end', teardown);
     });
     // 上游返回普通 HTTP 响应（非 101）：把状态码/头回写后断开，别让客户端永久挂起
     proxyReq.on('response', (proxyRes) => {


### PR DESCRIPTION
## 问题

WebSocket 转发路径（`lib/proxy.mjs` upgrade 段）只在 `'close'` 事件上清理对端连接：

```js
proxySocket.on('close', teardown);
socket.on('close', teardown);
```

但 `http.Server` 的 socket 默认 `allowHalfOpen = true`：收到对端 FIN 只触发 `'end'`，**永不触发 `'close'`**。于是手机浏览器/App 直接关页面（不发 WS close 帧就 FIN，刷新/杀进程很常见）时：

1. 客户端 FIN → 代理侧 server socket 进入 half-open（只 `'end'`，不自动关）
2. pipe 把 FIN 传给上游 → 上游同样 half-open 挂着
3. teardown 只在 `'close'` 触发 → **连接永久残留**

影响：每个这样关闭的页面永久占一个 dsh web 连接槽，直到系统 TCP 超时（数分钟甚至更久）。反复刷新/开关页面会堆积连接，最终耗尽连接槽。`server.close()` 也会永远等不完这个连接。

## 修复

双向转发里半关闭没有意义——收到 FIN（`'end'`）就销毁双方，与 `'close'` 同一 teardown：

```js
socket.on('end', teardown);
proxySocket.on('end', teardown);
```

## 验证

- 复现脚本：客户端 destroy 后观察上游连接 —— 修复前 `'end'` 后无任何事件（半开挂死），修复后两侧干净关闭
- `npm test`：89 pass / 2 fail（均为基线失败：WSL 检测需 Linux 环境、隧道恢复 flaky 重跑通过），无新增回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)