### PR TITLE
fix(lan): drop WSLENV from WSL detection

### DIFF
--- a/lib/service.mjs
+++ b/lib/service.mjs
@@ -83,7 +83,9 @@ export function detectWsl() {
     const v = readFileSync('/proc/version', 'utf8').toLowerCase();
     if (v.includes('microsoft') || v.includes('wsl')) return true;
   } catch { /* 非 Linux：无 /proc/version */ }
-  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP || process.env.WSLENV);
+  // 注意：**不能**用 WSLENV 判据——Windows Terminal 在原生 Windows 上也会设置
+  // WSLENV（如 WT_SESSION:WT_PROFILE_ID:），会误判成 WSL。只认 WSL 内部才有的变量。
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }
 
 /**

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -740,4 +740,15 @@ Ethernet adapter WLAN:
     else process.env.WSL_DISTRO_NAME = prev;
   }
   assert.equal(detectWsl(), false, '非 WSL 环境返回 false（macOS 无 /proc/version microsoft 标记）');
+
+  // WSLENV 由 Windows Terminal 在**原生 Windows** 上也会设置（WT_SESSION 等），
+  // 不能作为 WSL 判据——回归：仅设 WSLENV 不得误判为 WSL（issue #39 误报）。
+  const prevWslEnv = process.env.WSLENV;
+  process.env.WSLENV = 'WT_SESSION:WT_PROFILE_ID:';
+  try {
+    assert.equal(detectWsl(), false, '仅 WSLENV 不判定为 WSL（Windows Terminal 误报）');
+  } finally {
+    if (prevWslEnv === undefined) delete process.env.WSLENV;
+    else process.env.WSLENV = prevWslEnv;
+  }
 });


### PR DESCRIPTION
﻿## 概述

修复 detectWsl() 误判：去掉 WSLENV 作为 WSL 判定依据。

## 问题

Windows Terminal 在**原生 Windows** 上也会设置 WSLENV（如 WT_SESSION:WT_PROFILE_ID:），导致 detectWsl() 在非 WSL 环境下误返回 	rue，进而错误走 WSL 的 ipconfig 分支。

## 修复

- 只保留 /proc/version（含 microsoft/wsl）、WSL_DISTRO_NAME、WSL_INTEROP 三个可靠判据。
- 新增回归测试：仅设 WSLENV 不得判定为 WSL。

## 测试


pm test：70 通过，0 失败。
