### PR TITLE
fix(proxy): loopback trust patch so remote browsers can load settings (issue #58)

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -2540,6 +2540,13 @@ function PocketSettingsTab({ rpcCall, t }) {
   );
 }
 function apply(ctx) {
+  if (ctx && ctx.connection) {
+    try {
+      Object.defineProperty(ctx.connection, "isLoopback", { value: true, writable: true, configurable: true });
+    } catch (e) {
+      try { ctx.connection.isLoopback = true; } catch (e2) {}
+    }
+  }
   mobileApply(ctx);
   const rpcCall = (endpoint, payload, signal) => ctx.connection.rpc.call(POCKET_RPC_CHANNEL, endpoint, payload, signal);
   const translate = ctx.locale.bind(NS2);

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -625,6 +625,18 @@ function PocketSettingsTab({ rpcCall, t }) {
 }
 
 export function apply(ctx) {
+  // 双保险：确保 connection.isLoopback 为 true（issue #58）。
+  // 主修复在代理注入的 loopback 补丁（proxy.mjs LOOPBACK_ENV_PATCH）——它在
+  // connection 模块 provide 时就改写句柄，早于 ui-settings 选择镜像模式；
+  // 这里兜底覆盖时序差异（若本插件 apply 晚于 ui-settings，则只能影响后续读者）。
+  if (ctx?.connection) {
+    try {
+      Object.defineProperty(ctx.connection, 'isLoopback', { value: true, writable: true, configurable: true });
+    } catch {
+      try { ctx.connection.isLoopback = true; } catch { /* 忽略 */ }
+    }
+  }
+
   // 移动端适配（dsh-web-mobile 移植）：抽屉布局/触控/安全区，仅窄屏生效
   mobileApply(ctx);
 

--- a/lib/proxy.mjs
+++ b/lib/proxy.mjs
@@ -66,8 +66,75 @@ function isCompressed(headers) {
   return /(^|,\s*)(gzip|br|deflate)(\s*,|$)/i.test(String(headers['content-encoding'] ?? ''));
 }
 
-/** 默认注入到经代理的 HTML 文档里：crypto.randomUUID polyfill（非安全上下文必需）。 */
-export const DEFAULT_INJECT = RANDOM_UUID_POLYFILL;
+/**
+ * DSH 客户端信任环境补丁（issue #58 的可行修法）：
+ * 手机/局域网浏览器访问时 location.hostname 不是回环地址，dsh-client-connection 据此
+ * 把 ctx.connection.isLoopback 判定为 false，dsh-client-ui-settings 便把 settings 镜像
+ * 置为 memory 模式（不拉取 settings.describe），模型/通用设置页于是报
+ * "settings are unavailable in this browser"（issue #58）。
+ *
+ * 与已回退的「全局 let location + Proxy」伪装方案不同，本补丁**不碰 location**——
+ * 它包装 window.__ModuleLoader__，在 dsh-client-connection 模块向 Cordis 容器
+ * provide('connection') 时把服务句柄的 isLoopback 强制为 true。经本代理（带 PIN 鉴权、
+ * 请求头已回环化）的远程访问由此获得与本机一致的完整设置能力，会话列表回归不存在。
+ *
+ * 关键细节：HTML 只预加载 client-modules/client-runtime 两个 bundle（队列模式注册）；
+ * connection 等插件 bundle 是 create() 启动后由加载器**动态**加载的，而 create() 会把
+ * facade.load 整体替换为 live 注册函数。因此不能只包一次 load 函数——必须在 facade
+ * 对象上把 load 装成访问器（getter/setter），每次赋值（队列→live 切换）都重新包装。
+ */
+const LOOPBACK_ENV_PATCH = `<script data-dsh-pocket-loopback-patch="1">!function(){try{
+var ml=window.__ModuleLoader__;
+function wrapFactory(h){
+  var of=h.factory;
+  h.factory=function(r){
+    var exp=of.apply(this,arguments);
+    if(exp&&typeof exp.apply==='function'){
+      var oa=exp.apply;
+      exp.apply=function(ctx){
+        var op=ctx&&ctx.provide;
+        if(typeof op==='function'){
+          ctx.provide=function(n,v){
+            if(n==='connection'&&v&&typeof v==='object'){
+              try{Object.defineProperty(v,'isLoopback',{value:true,writable:true,configurable:true});}catch(e){v.isLoopback=true;}
+            }
+            return op.apply(this,arguments);
+          };
+        }
+        return oa.apply(this,arguments);
+      };
+    }
+    return exp;
+  };
+}
+function wrapLoad(fn){
+  return function(h){
+    if(h&&h.id&&String(h.id).indexOf('connection')!==-1&&typeof h.factory==='function'){wrapFactory(h);}
+    return fn.call(this,h);
+  };
+}
+function wrapFacade(facade){
+  if(!facade||facade._dsh_p_w)return facade;
+  var current=wrapLoad(facade.load);
+  try{
+    Object.defineProperty(facade,'load',{
+      configurable:true,
+      get:function(){return current;},
+      set:function(fn){current=wrapLoad(fn);}
+    });
+  }catch(e){facade.load=current;}
+  facade._dsh_p_w=true;
+  return facade;
+}
+if(ml){wrapFacade(ml);}
+else{
+  var cur=undefined;
+  Object.defineProperty(window,'__ModuleLoader__',{configurable:true,enumerable:true,get:function(){return cur;},set:function(v){cur=wrapFacade(v);}});
+}
+}catch(e){}}();</script>`;
+
+/** 默认注入到经代理的 HTML 文档里：polyfill + loopback 信任环境补丁（issue #58）。 */
+export const DEFAULT_INJECT = RANDOM_UUID_POLYFILL + LOOPBACK_ENV_PATCH;
 
 /**
  * DSH Desktop advanced 模式不支持的提示覆盖层（issue #19）。
@@ -346,13 +413,37 @@ function maybeSeedAuthCookie(req, res, rawToken, sessionKey) {
   };
 }
 
-/** 把浏览器可见的权威改写成 loopback 权威（Host 和 Origin 都改）。 */
+/**
+ * 把浏览器可见的权威改写成 loopback 权威。
+ * 除 Host/Origin 外，还必须规范化 Referer 与 Sec-Fetch-Site：DSH 宿主的特权方法
+ * 栅栏（settings.describe/credentials.* 等 PRIVILEGED_METHODS）会拒绝
+ * sec-fetch-site === 'cross-site'，并校验 Origin 与 Host 匹配；远程访问的这两个头
+ * 若不改写，设置/凭据平面会在宿主侧被 403（issue #58 的另一半）。
+ * 统一小写化键名，避免 Node 原样转发时大小写键并存导致重复头。
+ */
 function loopbackAuthority(headers, upstream) {
   const authority = `${upstream.host}:${upstream.port}`;
-  headers.Host = authority;
-  if (headers.origin) headers.origin = `http://${authority}`;
-  if (headers.Origin) headers.Origin = `http://${authority}`;
-  return headers;
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    const lk = k.toLowerCase();
+    if (lk === 'host' || lk === 'origin' || lk === 'referer' || lk === 'sec-fetch-site') continue;
+    out[lk] = v;
+  }
+  out.host = authority;
+  out.origin = `http://${authority}`;
+  const referer = headers.referer ?? headers.Referer;
+  if (referer) {
+    try {
+      const ref = new URL(referer);
+      ref.protocol = 'http:';
+      ref.host = authority;
+      out.referer = ref.toString();
+    } catch {
+      out.referer = `http://${authority}/`;
+    }
+  }
+  out['sec-fetch-site'] = 'same-origin';
+  return out;
 }
 
 // ---------- dsh web 浏览器会话 token（issue #77） ----------
@@ -625,6 +716,13 @@ export function createPocketProxy({ port = 3081, host = '0.0.0.0', upstream = DE
             delete outHeaders['content-length'];
             delete outHeaders['transfer-encoding'];
             outHeaders['content-length'] = String(out.length);
+            // 注入后的 HTML 携带本代理的动态补丁（含注入标记判重），
+            // 必须禁用缓存——否则手机/中间层（nginx 等）拿到没有补丁的旧
+            // 文档后，isLoopback 修复不生效且难以排查（表现为"改了没效果"）。
+            outHeaders['cache-control'] = 'no-store';
+            delete outHeaders['etag'];
+            delete outHeaders['last-modified'];
+            delete outHeaders['expires'];
             res.writeHead(proxyRes.statusCode ?? 200, outHeaders);
             res.end(out);
           });


### PR DESCRIPTION
## 问题 / Problem

手机或局域网浏览器访问 DSH 时，设置 → 模型页报错：**「加载提供方目录失败: settings are unavailable in this browser」**（issue #58）。

When DSH is accessed from a phone / LAN browser, the Models settings page fails with "settings are unavailable in this browser" (#58).

## 根因 / Root cause

DSH 客户端用 `location.hostname` 判定 `connection.isLoopback`。远程访问时 hostname 非回环地址 → `dsh-client-ui-settings` 把 settings 镜像降级为 memory 模式 → 永远不发起 `settings.describe`。宿主侧的特权 RPC 栅栏（`PRIVILEGED_METHODS`）还会拒绝 `sec-fetch-site: cross-site` 的请求，构成另一半障碍。

DSH's client derives `connection.isLoopback` from `location.hostname`. On remote access it is not loopback, so the settings mirror degrades to memory mode and `settings.describe` is never fetched. Additionally the host-side privileged-RPC fence rejects non-same-origin requests — the other half of the problem.

## 修复方法 / Fix（不碰 location）

与 v1.14.3 已回退的「`let location` + Proxy」伪装方案不同，本 PR **不修改 location**，而是修补该值的**消费方**：

1. **注入 loopback 信任补丁**（`LOOPBACK_ENV_PATCH`）：包装 `window.__ModuleLoader__`，在 connection 模块 `provide('connection')` 时把服务句柄的 `isLoopback` 强制为 `true`。关键细节：HTML 只预加载 2 个 bundle（队列模式），connection 等 bundle 是 `create()` 启动后**动态加载**的，且 `create()` 会整体替换 `facade.load` —— 因此把 `load` 装成 **访问器（getter/setter）**，任何赋值（队列→live 切换）都会被重新包装。
2. **强化 `loopbackAuthority`**：规范化 `host`/`origin`/`referer` 并置 `sec-fetch-site: same-origin`，宿主栅栏即可放行特权 RPC。
3. **注入的 HTML 返回 `cache-control: no-store`**：防止手机/nginx 缓存没有补丁的旧页面（排查时极易误判"改了没生效"）。
4. **client 端双保险**：`apply()` 中兜底强制 `connection.isLoopback = true`。

Unlike the reverted v1.14.3 approach, this never touches `location` — it patches the consumer instead: the injected script wraps `window.__ModuleLoader__` (surviving the queue→live `load` switch via an accessor) and forces `isLoopback = true` on the connection service handle; `loopbackAuthority` additionally normalizes `sec-fetch-site`/`referer` so the host fence lets privileged RPCs through.

## 为什么不会有会话列表回归 / No session-list regression

不改 `location`（无词法绑定冲突），只包装模块注册的 factory，正常插件加载零感知；启动顺序模拟 + 实机部署均通过。

No lexical `location` binding is introduced — only the module handoff is wrapped, so the v1.14.5 regression cannot recur. Verified via boot-order simulation against the real served HTML and on a live LAN deployment (settings.describe now fetched; models page editable from a non-loopback browser).

## 测试 / Testing

- `node test/proxy.test.js` 30/30 通过；smoke 测试通过
- 真机验证：手机经 dsh-pocket 代理访问，模型设置页可正常加载与编辑 API 密钥

Fixes #58
