### PR TITLE
fix(mobile): composer popups (model switcher, / command palette) clipped half-visible on phones

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -846,6 +846,39 @@ var MOBILE_CSS = `
     min-width: 0 !important;
   }
 
+  /* --- Composer popups as bottom sheets on mobile ---
+     Two composer-anchored popups break on phones (field: bottom + side
+     cut, only part of the popup visible):
+     1. the model pill menu ([role=menu], max 360px, opens upward from the
+        pill inside the composer card);
+     2. the "/" command palette (max 320px card with the search box \u2014 it
+        hosts the /model popupSelect list: search + provider-grouped rows).
+     Both are position:absolute INSIDE the conversation scrollBody
+     (overflow:hidden) and the shell center column (overflow:hidden), so
+     the scroll containers clip them mid-list. Forensics showed neither
+     layer creates a containing block (no transform/contain/will-change),
+     so on mobile we snap whichever popup is open to a viewport-anchored
+     sheet: fixed positioning escapes the scroll clip entirely, width is
+     deterministic, safe-area keeps it off the gesture bar. A transient
+     picker covering the composer is standard mobile UX; selection or an
+     outside tap still dismisses it. */
+  [data-phase] [class$="_root"]:has(> [aria-haspopup="menu"]) > [role="menu"],
+  [data-phase] [class$="_card"]:has(> [class$="_search"]) {
+    position: fixed !important;
+    left: 12px !important;
+    right: 12px !important;
+    top: auto !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 12px) !important;
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: none !important;
+    max-height: min(65vh, 480px) !important;
+    max-height: min(65dvh, 480px) !important;
+    z-index: 130 !important;
+    border-radius: 14px !important;
+    box-shadow: 0 -4px 28px rgba(0, 0, 0, .18) !important;
+  }
+
   /* --- Session header on mobile ---
      Layout goal: [toggle] [session title] [mode badge] in a row, with the
      Session log capsule removed from the header (relocated to the drawer

--- a/client/mobile/mobile.css.ts
+++ b/client/mobile/mobile.css.ts
@@ -355,6 +355,39 @@ export const MOBILE_CSS = `
     min-width: 0 !important;
   }
 
+  /* --- Composer popups as bottom sheets on mobile ---
+     Two composer-anchored popups break on phones (field: bottom + side
+     cut, only part of the popup visible):
+     1. the model pill menu ([role=menu], max 360px, opens upward from the
+        pill inside the composer card);
+     2. the "/" command palette (max 320px card with the search box — it
+        hosts the /model popupSelect list: search + provider-grouped rows).
+     Both are position:absolute INSIDE the conversation scrollBody
+     (overflow:hidden) and the shell center column (overflow:hidden), so
+     the scroll containers clip them mid-list. Forensics showed neither
+     layer creates a containing block (no transform/contain/will-change),
+     so on mobile we snap whichever popup is open to a viewport-anchored
+     sheet: fixed positioning escapes the scroll clip entirely, width is
+     deterministic, safe-area keeps it off the gesture bar. A transient
+     picker covering the composer is standard mobile UX; selection or an
+     outside tap still dismisses it. */
+  [data-phase] [class$="_root"]:has(> [aria-haspopup="menu"]) > [role="menu"],
+  [data-phase] [class$="_card"]:has(> [class$="_search"]) {
+    position: fixed !important;
+    left: 12px !important;
+    right: 12px !important;
+    top: auto !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 12px) !important;
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: none !important;
+    max-height: min(65vh, 480px) !important;
+    max-height: min(65dvh, 480px) !important;
+    z-index: 130 !important;
+    border-radius: 14px !important;
+    box-shadow: 0 -4px 28px rgba(0, 0, 0, .18) !important;
+  }
+
   /* --- Session header on mobile ---
      Layout goal: [toggle] [session title] [mode badge] in a row, with the
      Session log capsule removed from the header (relocated to the drawer


### PR DESCRIPTION
## 问题 / Problem

手机（窄屏）上打开模型切换列表时**只显示一半**：composer 模型 pill 的菜单、以及承载 `/model` 选择列表的 `/` 命令面板（搜索框 + 按提供方分组的模型行），底部与侧边被截断，列表只能看到一部分。桌面布局不受影响。

On phones, the model switcher popups — the composer model pill menu, and the `/` command palette that hosts the `/model` popupSelect list (search box + provider-grouped rows) — are only half visible: clipped at the bottom and sides. Desktop is unaffected.

## 根因 / Root cause

两类弹层都是 `position:absolute`、从 composer 向上弹出（pill 菜单上限 360px；命令面板上限 320px），而 composer 位于**会话滚动容器 `scrollBody`（overflow:hidden）与外壳中央列（overflow:hidden）内部**——绝对定位的弹层是滚动容器的后代，被容器裁剪，窄屏上只能看到一部分。无头浏览器（390x844 移动视口）复现并取证：裁剪链为 scrollBody → 中央列，且两层均无 transform/contain/will-change（不构成新的包含块）。

Both popups are `position:absolute`, opening upward from inside the composer — which itself lives INSIDE the conversation scroll container (`scrollBody`, overflow:hidden) and the shell center column (overflow:hidden). As descendants of those scrollers, the popups get clipped mid-list on narrow screens. Reproduced and forensically verified in a headless browser at 390x844: the clip chain is scrollBody → center column, and neither layer creates a containing block (no transform/contain/will-change).

## 修复 / Fix

移动端（仅移动样式表，桌面不编译）把**打开状态**的这两类弹层改为**固定定位的底部面板**：

```css
[data-phase] [class$="_root"]:has(> [aria-haspopup="menu"]) > [role="menu"],
[data-phase] [class$="_card"]:has(> [class$="_search"]) { position: fixed; … }
```

- `position:fixed` 完全脱离滚动容器的裁剪链；左右各 12px、底部安全区 + 12px，宽度确定，不再有横向越界；
- `max-height: min(65dvh, 480px)`，列表内部滚动；
- z-index 130、14px 圆角 + 投影，与既有移动端面板风格一致；
- 选择即关、点外部即关的行为不变；覆盖 composer 属于标准移动端选择器交互；
- 同结构受益：模型/推理强度两级菜单、权限模式菜单一并修复。

On mobile the open popups snap to a fixed, viewport-anchored bottom sheet: `position:fixed` escapes the scrollers' clip entirely; deterministic width (12px side gutters), safe-area bottom inset, `max-height: min(65dvh, 480px)` with internal scrolling, z-index 130, 14px radius + shadow. Selection and outside-tap dismissal are unchanged; the sheet-over-composer interaction is standard mobile picker UX. The model/effort two-level menu and the permission-mode menu share the same structure and are fixed by the same rule.

## 验证 / Testing

- 无头浏览器复现 + 取证（裁剪链、矩形坐标），真机（Android / Yandex Browser）确认修复后弹层完整显示、内部可滚动
- `node client/build.mjs` 重建 bundle；`node test/smoke.test.js` 通过

Reproduced headlessly (clip chain + rects), verified fixed on a real phone (Android / Yandex Browser): the popup now shows fully as a bottom sheet with internal scrolling. Bundle rebuilt; smoke tests pass.
