### PR TITLE
fix(mobile): restore compact usable composer (#89)

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -824,26 +824,44 @@ var MOBILE_CSS = `
     font-size: 15px !important;
   }
 
+  /* Keep DSH's own process disclosures and their expand/collapse behaviour,
+     but remove desktop-sized vertical breathing room between consecutive
+     context, Skill, and system-prompt entries. */
+  [data-phase] [data-turn-process] {
+    height: 28px !important;
+    padding-bottom: 4px !important;
+    margin-bottom: 4px !important;
+  }
+  [data-phase] [data-turn-process][data-open] {
+    margin-bottom: 4px !important;
+  }
+  [data-phase] [data-disclosure-row] {
+    min-height: 24px !important;
+  }
+  [data-phase] :is([data-context-injection-body], [data-system-prompt-body]) {
+    margin-top: 2px !important;
+  }
+
   /* --- Composer bottom row on mobile ---
-     The official row gives the model pill (trailing) flex:0 0 auto, which
-     squeezes the agent-permission pill (modes) down to 15px: the pill's
-     chevron then overflows on top of the model name. Let the permission
-     pill keep its natural width and let the model pill shrink instead.
-     Anchored by the composer card (:has(textarea)): row = last child,
-     tools = first child, permission pill = its 2nd child, model pill =
-     row's last child. */
-  [data-phase] [class*="_card"]:has(textarea) > :last-child {
+     Keep add, permission, model, reasoning and send controls on one line at
+     the Honor 50's 360px CSS viewport. DSH's stable data-composer-card hook
+     survives the editor's textarea -> contenteditable migration. */
+  [data-phase] [data-composer-card="true"] > [class$="_row"] {
+    flex-wrap: nowrap !important;
+    gap: 6px !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :first-child {
     gap: 8px !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :first-child {
-    gap: 8px !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :first-child > :nth-child(2) {
-    flex: 0 0 auto !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :last-child {
-    flex: 1 1 auto !important;
     min-width: 0 !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :first-child > :nth-child(2) {
+    flex: 0 1 auto !important;
+    min-width: 0 !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :last-child {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+    gap: 6px !important;
   }
 
   /* --- Session header on mobile ---
@@ -854,14 +872,22 @@ var MOBILE_CSS = `
        header > :first-child                   titleRow (titleCluster + utilities)
        header > :first-child > :last-child     headerUtilities (Session log seat) */
   [data-phase] header {
-    padding-right: 12px !important;
+    padding: 8px 12px 0 !important;
   }
-  /* Give the title row a lane clear of the absolutely-placed toggle, then
-     balance the header: with header padding-right 12px, a 20px left
-     padding puts the title's geometric center exactly on the viewport
-     center (measured 195/195 at 390px). */
+  /* The directory and Files controls are absolutely positioned, so reserve
+     their lanes and let the title use the remaining width without squeezing. */
   [data-phase] header > :first-child {
-    padding-left: 20px !important;
+    min-height: 36px !important;
+    padding: 0 32px !important;
+  }
+  [data-phase] header [class$="_titleCluster"],
+  [data-phase] header [class$="_crumbs"] {
+    min-width: 0 !important;
+  }
+  [data-phase] header button[class*="_crumb"] {
+    max-width: calc(100vw - 104px) !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
   /* The directory toggle sits at the far left of the header (the header
      is position:relative; the data-slot wrappers are display:contents). */
@@ -1588,11 +1614,10 @@ function mobileApply(ctx) {
       }
     };
     const mark = () => {
-      for (const root of document.querySelectorAll('[data-phase] [class$="_root"]')) {
-        if (root.closest('[class$="_composerStack"]') === null) continue;
+      const selector = '[data-phase] [data-slot="conversation.composer.dock"] [class$="_root"]';
+      for (const root of document.querySelectorAll(selector)) {
         const text = root.textContent ?? "";
         if (!/(turns|steps|\bLLM\b|轮|步)/.test(text)) continue;
-        if (root.querySelector("textarea") !== null) continue;
         root.setAttribute("data-mobile-nav", "stats");
         moveTps(root);
         return;

--- a/client/mobile/mobile-apply.tsx
+++ b/client/mobile/mobile-apply.tsx
@@ -182,11 +182,10 @@ export function mobileApply(ctx): void {
 
   // The official conversation status row (turns / steps / LLM time / TTFT /
   // cache) has a hashed class, so the stylesheet cannot target it directly.
-  // Mark the exact row on narrow screens by text: a [class$=_root] that
-  // carries the metrics text and no textarea (the composer card also ends in
-  // _root and can mention turns in its model line). The CSS then lays the
-  // marked row out as ONE horizontally scrolling line with every metric
-  // reachable.
+  // Its stable boundary is the official conversation.composer.dock slot. Mark
+  // only the metrics root inside that slot; never scan every *_root under the
+  // composer because the editor itself is now contenteditable (not textarea)
+  // and its root also contains the dock text.
   ctx.effect(() => {
     if (!narrow.matches) return () => {}
     // The composer root renders the TPS readout ("TPS 89.4 tok/s") as its
@@ -206,13 +205,10 @@ export function mobileApply(ctx): void {
       }
     }
     const mark = (): void => {
-      for (const root of document.querySelectorAll('[data-phase] [class$="_root"]')) {
-        // The status row lives inside the composer stack; message-area
-        // blocks can also mention turns/steps and must be skipped.
-        if (root.closest('[class$="_composerStack"]') === null) continue
+      const selector = '[data-phase] [data-slot="conversation.composer.dock"] [class$="_root"]'
+      for (const root of document.querySelectorAll(selector)) {
         const text = root.textContent ?? ''
         if (!/(turns|steps|\bLLM\b|轮|步)/.test(text)) continue
-        if (root.querySelector('textarea') !== null) continue
         root.setAttribute('data-mobile-nav', 'stats')
         moveTps(root)
         return

--- a/client/mobile/mobile.css.ts
+++ b/client/mobile/mobile.css.ts
@@ -333,26 +333,44 @@ export const MOBILE_CSS = `
     font-size: 15px !important;
   }
 
+  /* Keep DSH's own process disclosures and their expand/collapse behaviour,
+     but remove desktop-sized vertical breathing room between consecutive
+     context, Skill, and system-prompt entries. */
+  [data-phase] [data-turn-process] {
+    height: 28px !important;
+    padding-bottom: 4px !important;
+    margin-bottom: 4px !important;
+  }
+  [data-phase] [data-turn-process][data-open] {
+    margin-bottom: 4px !important;
+  }
+  [data-phase] [data-disclosure-row] {
+    min-height: 24px !important;
+  }
+  [data-phase] :is([data-context-injection-body], [data-system-prompt-body]) {
+    margin-top: 2px !important;
+  }
+
   /* --- Composer bottom row on mobile ---
-     The official row gives the model pill (trailing) flex:0 0 auto, which
-     squeezes the agent-permission pill (modes) down to 15px: the pill's
-     chevron then overflows on top of the model name. Let the permission
-     pill keep its natural width and let the model pill shrink instead.
-     Anchored by the composer card (:has(textarea)): row = last child,
-     tools = first child, permission pill = its 2nd child, model pill =
-     row's last child. */
-  [data-phase] [class*="_card"]:has(textarea) > :last-child {
+     Keep add, permission, model, reasoning and send controls on one line at
+     the Honor 50's 360px CSS viewport. DSH's stable data-composer-card hook
+     survives the editor's textarea -> contenteditable migration. */
+  [data-phase] [data-composer-card="true"] > [class$="_row"] {
+    flex-wrap: nowrap !important;
+    gap: 6px !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :first-child {
     gap: 8px !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :first-child {
-    gap: 8px !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :first-child > :nth-child(2) {
-    flex: 0 0 auto !important;
-  }
-  [data-phase] [class*="_card"]:has(textarea) > :last-child > :last-child {
-    flex: 1 1 auto !important;
     min-width: 0 !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :first-child > :nth-child(2) {
+    flex: 0 1 auto !important;
+    min-width: 0 !important;
+  }
+  [data-phase] [data-composer-card="true"] > [class$="_row"] > :last-child {
+    flex: 1 1 0 !important;
+    min-width: 0 !important;
+    gap: 6px !important;
   }
 
   /* --- Session header on mobile ---
@@ -363,14 +381,22 @@ export const MOBILE_CSS = `
        header > :first-child                   titleRow (titleCluster + utilities)
        header > :first-child > :last-child     headerUtilities (Session log seat) */
   [data-phase] header {
-    padding-right: 12px !important;
+    padding: 8px 12px 0 !important;
   }
-  /* Give the title row a lane clear of the absolutely-placed toggle, then
-     balance the header: with header padding-right 12px, a 20px left
-     padding puts the title's geometric center exactly on the viewport
-     center (measured 195/195 at 390px). */
+  /* The directory and Files controls are absolutely positioned, so reserve
+     their lanes and let the title use the remaining width without squeezing. */
   [data-phase] header > :first-child {
-    padding-left: 20px !important;
+    min-height: 36px !important;
+    padding: 0 32px !important;
+  }
+  [data-phase] header [class$="_titleCluster"],
+  [data-phase] header [class$="_crumbs"] {
+    min-width: 0 !important;
+  }
+  [data-phase] header button[class*="_crumb"] {
+    max-width: calc(100vw - 104px) !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
   /* The directory toggle sits at the far left of the header (the header
      is position:relative; the data-slot wrappers are display:contents). */

--- a/test/mobile-nav.test.js
+++ b/test/mobile-nav.test.js
@@ -141,6 +141,28 @@ test('打包产物里带上抽屉规则的关键字', () => {
   }
 });
 
+test('composer 底栏用稳定 card 标记并在 360px 视口保持单行', () => {
+  const css = readFileSync(new URL('../client/mobile/mobile.css.ts', import.meta.url), 'utf8');
+  assert.ok(css.includes('[data-composer-card="true"] > [class$="_row"]'));
+  assert.ok(css.includes('flex-wrap: nowrap !important'));
+  assert.ok(
+    !css.includes('[class*="_card"]:has(textarea) > :last-child'),
+    '会话 composer 底栏不能再依赖 textarea',
+  );
+});
+
+test('统计行只从 composer.dock 标记，不误标 contenteditable composer 根节点', () => {
+  const src = readFileSync(new URL('../client/mobile/mobile-apply.tsx', import.meta.url), 'utf8');
+  assert.ok(
+    src.includes('[data-slot="conversation.composer.dock"] [class$="_root"]'),
+    '统计行必须限定在 DSH 的 conversation.composer.dock 稳定插槽内',
+  );
+  assert.ok(
+    !src.includes("document.querySelectorAll('[data-phase] [class$=\"_root\"]')"),
+    '不能扫描 composer 内所有 *_root；新版编辑器是 contenteditable，会让 composer 根误命中',
+  );
+});
+
 test('打包产物：mobile-apply 引用的组件都有 import 且有定义', () => {
   const src = readFileSync(new URL('../client/mobile/mobile-apply.tsx', import.meta.url), 'utf8');
   const bundle = readFileSync(new URL('../client/client.js', import.meta.url), 'utf8');


### PR DESCRIPTION
Closes #89

## 问题

窄视口（手机）下对话页信息密度过高：composer 卡片底部换行导致输入区被挤压，回复完成后输入框几乎不可见。

## 根因（390px 与 360px 真实视口复现实测）

1. 统计行标记扫描 `[data-phase] [class$="_root"]` 时，新版 DSH 编辑器已从 `<textarea>` 改为 `contenteditable`，旧的 `querySelector('textarea')` 排除条件失效，composer 根节点被误标为 `data-mobile-nav="stats"`，随后被统计行 CSS 压缩到 28px。
2. composer 底栏定位规则依赖 `[class*="_card"]:has(textarea)`，在 contenteditable 编辑器下永不匹配；DSH 原生 row 允许 `flex-wrap: wrap`，360px 视口（荣耀 50）下权限、模型、推理等级和发送控件换成两行，卡片高度从 94px 膨胀到 134px。

## 修复

- 统计行只在 DSH 稳定插槽 `[data-slot="conversation.composer.dock"]` 内标记真正的 metrics 根节点，不再扫描 composer 全部 `*_root`。
- composer 底栏改用稳定标记 `[data-composer-card="true"]`，并在移动端保持单行（`flex-wrap: nowrap`），允许权限/模型 pill 收缩。
- 会话头部与原生 disclosure 只收紧多余留白，不改变 DSH 自带展开/折叠行为。

## 验证

- `npm run build:client` 通过。
- `node --test test/mobile-nav.test.js` 12/12 通过（新增 2 条回归：统计行不误标 contenteditable composer 根节点；底栏在 360px 视口保持单行）。
- 真实设备（荣耀 50，360px CSS 视口）与桌面 390px 视口截图验证：composer 完整可见，底部控件单行排列。